### PR TITLE
Fix old-style params

### DIFF
--- a/model_metadata/model_info.py
+++ b/model_metadata/model_info.py
@@ -212,6 +212,8 @@ class ModelInfo(object):
 
     @staticmethod
     def norm(params):
+        if params.pop('initialize_args', None):
+            warnings.warn("ignoring 'initialize_args' in info section")
         name = params.pop('name', '?')
         return ModelInfo(name, **params).as_dict()
 

--- a/model_metadata/model_info.py
+++ b/model_metadata/model_info.py
@@ -212,8 +212,9 @@ class ModelInfo(object):
 
     @staticmethod
     def norm(params):
-        if params.pop('initialize_args', None):
-            warnings.warn("ignoring 'initialize_args' in info section")
+        for key in ('initialize_args', 'class', 'id'):
+            if params.pop(key, None):
+                warnings.warn("ignoring '{0}' in info section".format(key))
         name = params.pop('name', '?')
         return ModelInfo(name, **params).as_dict()
 

--- a/model_metadata/model_parameter.py
+++ b/model_metadata/model_parameter.py
@@ -175,7 +175,7 @@ def parameter_from_dict(d):
 
     if dtype in ('float', 'double'):
         return FloatParameter(value, **kwds)
-    elif dtype in ('int', 'integer'):
+    elif dtype in ('int', 'integer', 'long'):
         return IntParameter(value, **kwds)
     elif dtype in ('str', 'string'):
         return StringParameter(value, **kwds)


### PR DESCRIPTION
This pull request allows for reading some old-style metadata files that contain parameters that no longer exist. In particular, some keys in `info.yaml` have been removed. In this case they are ignored and a warning issued.

For data types in `parameters.yaml` `long` is now used as a synonym for `int`.