### PR TITLE
Use Version from packaging.version.

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 requirements:
   build:
     - python
+    - packaging
     - setuptools
     - pyyaml
     - six
@@ -19,6 +20,7 @@ requirements:
 
   run:
     - python
+    - packaging
     - numpy
     - six
     - pyyaml

--- a/model_metadata/model_info.py
+++ b/model_metadata/model_info.py
@@ -4,7 +4,7 @@ import warnings
 from pprint import pformat
 
 import six
-from pkg_resources import parse_version, SetuptoolsLegacyVersion
+from packaging.version import Version, InvalidVersion
 import yaml
 
 from .metadata.load import load_meta_section
@@ -112,10 +112,10 @@ def validate_doi(doi):
 
 def validate_version(version):
     """Validate a version string."""
-    v = parse_version(version)
-    if isinstance(v, SetuptoolsLegacyVersion):
-        warnings.warn(
-            '{v}: version string does not follow PEP440'.format(v=v))
+    try:
+        Version(version)
+    except InvalidVersion:
+        warnings.warn('{v}: version string does not follow PEP440'.format(v=v))
     return version
 
 


### PR DESCRIPTION
The pull request fixes #6.

`SetuptoolsLegacyVersion` and `parse_version` from `setuptools` has been deprecated for a while and is now gone in version 39. I've simply replaced with equivalents from `packaging.version`.