### PR TITLE
Build and run tests in an environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda config --add channels csdms-stack
 - conda config --add channels conda-forge
-- conda install python=$TRAVIS_PYTHON_VERSION
+- conda create -n _testing python=$TRAVIS_PYTHON_VERSION
+- source activate _testing
 - conda install -q conda-build anaconda-client sphinx
-- conda update -n root conda-build -c defaults
 script:
 - conda build ./conda-recipe --no-test --old-build-string
 - conda install model_metadata nose coverage --use-local


### PR DESCRIPTION
This pull request fixes the `UnsatisfiableError` we see on Travis when we try to install, for example, Python 2.7 into a Miniconda3 installation. Now we just create a new environment, with the target Python version, in which the build/tests are run.