### PR TITLE
Use binaryornot package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,7 @@ install:
 - source activate _testing
 - conda install -q conda-build anaconda-client sphinx
 script:
-- conda build ./conda-recipe --no-test --old-build-string
-- conda install model_metadata nose coverage --use-local
-- nosetests --detailed-errors --exclude=examples --with-doctest --with-coverage --cover-package=model_metadata
-  --verbosity=2 model_metadata
+- conda build ./conda-recipe --old-build-string
 after_success:
 - |
   if [[ $TRAVIS_OS_NAME == "linux" ]]; then

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
     - six
     - jinja2
     - scripting
+    - packaging
+    - binaryornot
 
   run:
     - python
@@ -27,6 +29,8 @@ requirements:
     - six
     - jinja2
     - scripting
+    - packaging
+    - binaryornot
 
 test:
   requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -34,11 +34,9 @@ requirements:
 
 test:
   requires:
-    - nose
-    - coverage [linux]
+    - pytest
   commands:
-    - nosetests --with-doctest --with-coverage --cover-package=model_metadata model_metadata [linux]
-    - nosetests --with-doctest model_metadata [not linux]
+    - pytest --pyargs model_metadata --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
 
 build:
   number: 0

--- a/model_metadata/model_setup.py
+++ b/model_metadata/model_setup.py
@@ -5,6 +5,7 @@ import errno
 import shutil
 
 from scripting.contexts import cd
+from binaryornot.check import is_binary
 
 from .metadata import find_model_data_files
 from .model_data_files import format_template_file, FileTemplate
@@ -108,7 +109,7 @@ class FileSystemLoader(object):
 
         if os.path.isdir(src):
             mkdir_p(relpath)
-        elif is_text_file(src):
-            FileTemplate(src).to_file(relpath, **kwds)
-        else:
+        elif is_binary(src):
             shutil.copy2(src, relpath)
+        else:
+            FileTemplate(src).to_file(relpath, **kwds)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[tool:pytest]
+minversion = 3.0
+testpaths = model_metadata
+norecursedirs = .* *.egg* build dist
+addopts =
+    --ignore setup.py
+    --ignore versioneer.py
+    --ignore model_metadata/_version.py
+    --tb native
+    --strict
+    --durations 16
+    --doctest-modules
+doctest_optionflags =
+    NORMALIZE_WHITESPACE
+    IGNORE_EXCEPTION_DETAIL
+    ALLOW_UNICODE


### PR DESCRIPTION
Use the `binaryornot` package for testing if files are binary (or not). It seems to be a little more robust than our homegrown version and it also fixes a Python 3 error that our version has.