### PR TITLE
Return config file after stage

### DIFF
--- a/model_metadata/cli/main_stage.py
+++ b/model_metadata/cli/main_stage.py
@@ -54,7 +54,8 @@ def execute(args):
         raise MetadataNotFoundError(args.model)
 
     defaults = dict()
-    for param, item in ModelMetadata(mmd).parameters.items():
+    meta = ModelMetadata(mmd)
+    for param, item in meta.parameters.items():
         defaults[param] = item["value"]["default"]
 
     if args.jinja:
@@ -72,6 +73,10 @@ def execute(args):
                     shutil.copy2(os.path.join(mmd, fname), fname)
     else:
         OldFileSystemLoader(mmd).stage_all(args.dest, **defaults)
+
+    config_file = meta.run["config_file"]["path"]
+    if config_file:
+        print(config_file, file=sys.stdout)
 
 
 def main():

--- a/model_metadata/model_setup.py
+++ b/model_metadata/model_setup.py
@@ -79,8 +79,8 @@ def mkdir_p(path):
 
 class FileSystemLoader(object):
     def __init__(self, searchpath):
-        self._base = searchpath
-        self._files = find_model_data_files(searchpath)
+        self._base = os.path.abspath(searchpath)
+        self._files = find_model_data_files(self._base)
 
     @property
     def base(self):


### PR DESCRIPTION
Changed the `mmd-stage` command to return the name of the config file (as given in the `run.yaml` file). This is useful when, for example, staging a model and then running the `bmi-test` on it (which needs the name of the input file).

`bmi-test` could now be run something like,
```bash
$ bmi-test permamodel.components.bmi_frost_number_Geo:BmiFrostnumberGeoMethod --infile=$(mmd-stage BmiFrostnumberGeoMethod .)
```