### PR TITLE
Change mmd-stage to print manifest

### DIFF
--- a/model_metadata/cli/main_query.py
+++ b/model_metadata/cli/main_query.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python
+from __future__ import print_function
+
+import os
+import sys
+import argparse
+import textwrap
+
+from ..modelmetadata import ModelMetadata
+from ..errors import MissingSectionError, MissingValueError
+
+
+def configure_parser_mmd_query(sub_parsers=None):
+    help = "get info about a model"
+
+    example = textwrap.dedent(
+        """
+
+    Examples:
+
+    mmd query Child --var=run
+
+    """
+    )
+    if sub_parsers is None:
+        p = argparse.ArgumentParser(
+            description=help, fromfile_prefix_chars="@", epilog=example
+        )
+    else:
+        p = sub_parsers.add_parser("query", help=help, description=help, epilog=example)
+    p.add_argument("model", type=str, help="model to query")
+    p.add_argument(
+        "--var", action="append", type=str, help="name of variable or section"
+    )
+
+    p.set_defaults(func=execute)
+
+    return p
+
+
+def execute(args):
+    if os.path.isdir(args.model):
+        path_to_mmd = args.model
+    else:
+        path_to_mmd = os.path.join(sys.prefix, "share", "csdms", args.model)
+    if not os.path.isdir(path_to_mmd):
+        raise MetadataNotFoundError(args.model)
+
+    if args.var:
+        meta = ModelMetadata(path_to_mmd)
+        for var in args.var:
+            try:
+                print(meta.get(var), file=sys.stdout)
+            except MissingSectionError as err:
+                print("{0}: Missing section".format(err.name), file=sys.stderr)
+            except MissingValueError as err:
+                print("{0}: Missing value".format(err.name), file=sys.stderr)
+
+
+def main():
+    import argparse
+
+    p = configure_parser_mmd_query()
+
+    args = p.parse_args()
+
+    args.func(args)

--- a/model_metadata/cli/main_stage.py
+++ b/model_metadata/cli/main_stage.py
@@ -44,11 +44,6 @@ def configure_parser_mmd_stage(sub_parsers=None):
         help="supress printing the manifest to the screen",
     )
     p.add_argument(
-        "--manifest-file",
-        type=str,
-        help="write manifest of staged files to a file instead of the screen",
-    )
-    p.add_argument(
         "--old-style-templates", action="store_true", help="use old-style templates"
     )
 
@@ -77,10 +72,7 @@ def execute(args):
         manifest = FileSystemLoader(mmd).stage_all(args.dest, **defaults)
     manifest = os.linesep.join(manifest)
 
-    if args.manifest_file is not None:
-        with open(args.manifest_file, "w") as fp:
-            print(manifest, file=fp)
-    elif not args.quiet:
+    if not args.quiet:
         print(manifest, file=sys.stdout)
 
 

--- a/model_metadata/errors.py
+++ b/model_metadata/errors.py
@@ -17,3 +17,33 @@ class MetadataNotFoundError(ModelMetadataError):
 
     def __str__(self):
         return self._path
+
+
+class MissingSectionError(ModelMetadataError):
+
+    """Raise if a section in not found in the metadata."""
+
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+    def __str__(self):
+        return self._name
+
+
+class MissingValueError(ModelMetadataError):
+
+    """Raise if a value is not found in a metadata section."""
+
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+    def __str__(self):
+        return self._name

--- a/model_metadata/model_data_files.py
+++ b/model_metadata/model_data_files.py
@@ -55,6 +55,8 @@ class FileTemplate(object):
         with open(dest, "w") as fp:
             fp.write(self.render(**kwds))
 
+        return dest
+
     @staticmethod
     def format(file_like, **kwds):
         try:

--- a/model_metadata/modelmetadata.py
+++ b/model_metadata/modelmetadata.py
@@ -13,6 +13,7 @@ from .model_parameter import (
     parameter_from_dict,
 )
 from .model_info import ModelInfo
+from .errors import MissingSectionError, MissingValueError
 
 
 setup_yaml_with_canonical_dict()
@@ -66,6 +67,27 @@ class ModelMetadata(object):
                     name=name
                 )
             )
+
+    def get(self, key):
+        """Get a metadata value with dotted notation.
+
+        Parameters
+        ----------
+        key : str
+            Name of a value or section in dotted notation. For example,
+            `run.config_file.path`.
+        """
+        val, section = self._meta, ""
+        for name in key.split("."):
+            section = ".".join([section, name])
+            try:
+                val = val[name]
+            except KeyError:
+                raise MissingSectionError(section)
+            except TypeError:
+                raise MissingValueError(section)
+
+        return val
 
     @property
     def base(self):

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
             "mmd-stage=model_metadata.cli.main_stage:main",
             "mmd-dump=model_metadata.cli.main_dump:main",
             "mmd-install=model_metadata.cli.main_install:main",
+            "mmd-query=model_metadata.cli.main_query:main",
         ],
         "bmi.plugins": ["bmi_mmd=model_metadata.cli.main:configure_parser_mmd"],
     },


### PR DESCRIPTION
This pull request changes `mmd-stage` to print a manifest of the staged files to the display. The manifest can, optionally, be written to a file with the `--manifest` command. To suppress output, use the new `--quiet` option.

In addition, this pull request adds a new command, `mmd-query` that prints metadata values to the screen. Values are specified in dotted-notation. For example,
```bash
$ mmd-query <name-of-model> --var=run.config_file.path
```