### PR TITLE
Fix typo in mmd-stage command.

### DIFF
--- a/model_metadata/cli/main_stage.py
+++ b/model_metadata/cli/main_stage.py
@@ -49,7 +49,7 @@ def execute(args):
         args.model, dest=args.dest, old_style_templates=args.old_style_templates
     )
     if not args.quiet:
-        print(os.linsep.join(manifest), file=sys.stdout)
+        print(os.linesep.join(manifest), file=sys.stdout)
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
     author="Eric Hutton",
     author_email="huttone@colorado.edu",
     url="http://csdms.colorado.edu",
-    install_requires=read_requirements(),
     setup_requires=["setuptools"],
     packages=find_packages(),
     cmdclass=versioneer.get_cmdclass(),


### PR DESCRIPTION
This pull request fixes a small typo in `main_stage` (`linsep` instead of `linesep`) that caused the `mmd-stage` command to fail.