### PR TITLE
Use click for command line interface

### DIFF
--- a/model_metadata/cli/main.py
+++ b/model_metadata/cli/main.py
@@ -1,58 +1,171 @@
-import argparse
-import textwrap
+import importlib
+import os
+import re
+import sys
 
-from .. import __version__
-from .main_dump import configure_parser_mmd_dump
-from .main_find import configure_parser_mmd_find
-from .main_install import configure_parser_mmd_install
-from .main_stage import configure_parser_mmd_stage
+import click
+
+from ..api import query as _query, stage as _stage, find as _find, _search_paths
+from ..errors import MetadataNotFoundError, MissingSectionError, MissingValueError
+from ..modelmetadata import ModelMetadata
 
 
-def configure_parser_mmd(sub_parsers=None):
-    help = "Model metadata tools"
+class MetadataLocationParamType(click.Path):
+    name = "metadata"
 
-    example = textwrap.dedent(
-        """
+    def convert(self, value, param, ctx):
 
-    Examples:
+        try:
+            validate_entry_point(ctx, param, value)
+        except (ValueError, click.BadParameter):
+            model = value
+        else:
+            model = _find(load_component(value))
 
-    mmd --version
+        for p in _search_paths(model):
+            try:
+                return super(MetadataLocationParamType, self).convert(p, param, ctx)
+            except Exception:
+                pass
 
-    """
-    )
-    if sub_parsers is None:
-        p = argparse.ArgumentParser(
-            description=help, fromfile_prefix_chars="@", epilog=example
-        )
+        return super(MetadataLocationParamType, self).convert(value, param, ctx)
+
+        try:
+            return super(MetadataLocationParamType, self).convert(value, param, ctx)
+        except Exception:
+            raise
+
+
+def validate_entry_point(ctx, param, value):
+    MODULE_REGEX = r"^(?!.*\.\.)(?!.*\.$)[A-Za-z][\w\.]*$"
+    CLASS_REGEX = r"^[_a-zA-Z][_a-zA-Z0-9]+$"
+    if value is not None:
+        try:
+            module_name, class_name = value.split(":")
+        except ValueError:
+            raise click.BadParameter(
+                "Bad entry point", param=value, param_hint="module_name:ClassName"
+            )
+        if not re.match(MODULE_REGEX, module_name):
+            raise click.BadParameter(
+                "Bad module name ({0})".format(module_name),
+                param_hint="module_name:ClassName",
+            )
+        if not re.match(CLASS_REGEX, class_name):
+            raise click.BadParameter(
+                "Bad class name ({0})".format(class_name),
+                param_hint="module_name:ClassName",
+            )
+    return value
+
+
+def load_component(entry_point):
+    if "" not in sys.path:
+        sys.path.append("")
+
+    module_name, cls_name = entry_point.split(":")
+
+    component = None
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        raise
     else:
-        p = sub_parsers.add_parser("mmd", help=help, description=help, epilog=example)
-    # p.add_argument(
-    #     'name',
-    #     help='name of model',
-    # )
+        try:
+            component = module.__dict__[cls_name]
+        except KeyError:
+            raise ImportError(cls_name)
 
-    p.add_argument(
-        "-V",
-        "--version",
-        action="version",
-        version="mmd {0}".format(__version__),
-        help="Show the mmd version number and exit.",
-    )
-
-    sub_parsers = p.add_subparsers(metavar="command", dest="cmd")
-    sub_parsers.required = True
-    # p.set_defaults(func=execute)
-
-    configure_parser_mmd_find(sub_parsers)
-    configure_parser_mmd_stage(sub_parsers)
-    configure_parser_mmd_dump(sub_parsers)
-    configure_parser_mmd_install(sub_parsers)
-
-    return p
+    return component
 
 
-def main():
-    p = configure_parser_mmd()
-    args = p.parse_args()
+@click.group()
+@click.version_option()
+def mmd():
+    pass
 
-    args.func(args)
+
+@mmd.command()
+@click.argument(
+    "metadata",
+    type=MetadataLocationParamType(
+        exists=True, file_okay=False, dir_okay=True, writable=False, resolve_path=True
+    ),
+)
+def find(metadata):
+    sys.path.append("")
+    try:
+        click.secho(str(_find(metadata)), err=False)
+    except MetadataNotFoundError:
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+@mmd.command()
+@click.argument(
+    "metadata",
+    type=MetadataLocationParamType(
+        exists=True, file_okay=False, dir_okay=True, writable=False, resolve_path=True
+    ),
+)
+@click.option("--var", multiple=True, help="name of variable or section")
+@click.option("--all", is_flag=True, help="query all sections")
+def query(metadata, var, all):
+    if all:
+        vars = ModelMetadata.SECTIONS
+    else:
+        vars = var
+
+    values, errors = {}, {}
+    for name in vars:
+        try:
+            value = _query(metadata, name)
+        except MissingSectionError as err:
+            errors[name] = "{0}: Missing section".format(err.name)
+        except MissingValueError as err:
+            errors[name] = "{0}: Missing value".format(err.name)
+        else:
+            values[name] = value
+
+    if errors:
+        for error in errors.values():
+            click.secho(error, err=True, fg="red")
+    else:
+        click.echo_via_pager(ModelMetadata.format(values))
+
+    sys.exit(len(errors))
+
+
+@mmd.command()
+@click.argument(
+    "metadata",
+    type=click.Path(
+        exists=True, file_okay=False, dir_okay=True, writable=False, resolve_path=True
+    ),
+)
+@click.argument(
+    "dest",
+    type=click.Path(
+        exists=True, file_okay=False, dir_okay=True, writable=True, resolve_path=True
+    ),
+)
+@click.option(
+    "-q",
+    "--quiet",
+    is_flag=True,
+    help="supress printing the manifest to the screen",
+)
+@click.option("--old-style-templates", is_flag=True, help="use old-style templates")
+def stage(metadata, dest, quiet, old_style_templates):
+    try:
+        manifest = _stage(
+            metadata, dest=dest, old_style_templates=old_style_templates
+        )
+    except MetadataNotFoundError as err:
+        click.secho(err, err=True)
+        sys.exit(1)
+
+    if not quiet:
+        click.secho(os.linesep.join(manifest), err=False)
+    sys.exit(0)

--- a/model_metadata/modelmetadata.py
+++ b/model_metadata/modelmetadata.py
@@ -87,6 +87,10 @@ class ModelMetadata(object):
 
         return val
 
+    @staticmethod
+    def format(value):
+        return yaml.safe_dump(value)
+
     @property
     def base(self):
         return self._path

--- a/setup.py
+++ b/setup.py
@@ -47,14 +47,7 @@ setup(
     packages=find_packages(),
     cmdclass=versioneer.get_cmdclass(),
     entry_points={
-        "console_scripts": [
-            "mmd=model_metadata.cli.main:main",
-            "mmd-find=model_metadata.cli.main_find:main",
-            "mmd-stage=model_metadata.cli.main_stage:main",
-            "mmd-dump=model_metadata.cli.main_dump:main",
-            "mmd-install=model_metadata.cli.main_install:main",
-            "mmd-query=model_metadata.cli.main_query:main",
-        ],
+        "console_scripts": ["mmd=model_metadata.cli.main:mmd"],
         "bmi.plugins": ["bmi_mmd=model_metadata.cli.main:configure_parser_mmd"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     setup_requires=["setuptools"],
     install_requires=[
         "binaryornot",
+        "click",
         "jinja2",
         "packaging",
         "pyyaml",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture
+def model_as_object():
+    class Model:
+        METADATA = "path"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import pathlib
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -88,4 +89,7 @@ def test_find_absolute_path(datadir):
     os.chdir(datadir)
     result = runner.invoke(mmd, ["find", "model:ModelAbsolutePath"])
     assert result.exit_code == 0
-    assert result.stdout.strip() == "/"
+    if sys.platform.startswith("win"):
+        assert result.stdout.strip() == r"C:\\"
+    else:
+        assert result.stdout.strip() == "/"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+import os
+import pathlib
+
+import pytest
+from click.testing import CliRunner
+
+from model_metadata.cli.main import mmd
+
+
+def test_command_line_interface():
+    """Test the CLI."""
+    runner = CliRunner()
+    result = runner.invoke(mmd, ["--help"])
+    assert result.exit_code == 0
+
+    result = runner.invoke(mmd, ["--version"])
+    assert result.exit_code == 0
+    assert "version" in result.output
+
+
+@pytest.mark.parametrize("subcommand", ("find", "query", "stage"))
+def test_subcommand_help(subcommand):
+    runner = CliRunner()
+    result = runner.invoke(mmd, [subcommand, "--help"])
+    assert result.exit_code == 0
+
+
+def test_stage_subcommand(tmpdir, shared_datadir):
+    runner = CliRunner()
+    stagedir = pathlib.Path(tmpdir / "stagedir")
+    stagedir.mkdir()
+    with tmpdir.as_cwd():
+        result = runner.invoke(mmd, ["stage", str(shared_datadir), str(stagedir)])
+        assert result.exit_code == 0
+        manifest = result.stdout.splitlines()
+        assert set(stagedir.iterdir()) == set([stagedir / fname for fname in manifest])
+
+
+def test_stage_subcommand_without_manifest(tmpdir, shared_datadir):
+    runner = CliRunner()
+    stagedir = pathlib.Path(tmpdir / "stagedir")
+    stagedir.mkdir()
+    with tmpdir.as_cwd():
+        result = runner.invoke(mmd, ["stage", "-q", str(shared_datadir), str(stagedir)])
+        assert set(stagedir.iterdir()) == set([stagedir / "child.in"])
+        assert result.exit_code == 0
+        assert result.stdout == ""
+
+
+def test_query_subcommand(shared_datadir):
+    runner = CliRunner()
+    result = runner.invoke(mmd, ["query", str(shared_datadir), "--var", "info.version"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "info.version: '10.6'"
+
+
+def test_query_subcommand_missing_values(shared_datadir):
+    runner = CliRunner()
+    result = runner.invoke(
+        mmd, ["query", str(shared_datadir), "--var", "not_a_section"]
+    )
+    assert result.exit_code == 1
+    result = runner.invoke(
+        mmd,
+        [
+            "query",
+            str(shared_datadir),
+            "--var=not_a_section",
+            "--var=also_not_a_section",
+        ],
+    )
+    assert result.exit_code == 2
+
+
+@pytest.mark.parametrize("entry_point", ("model:ModelString", "model:ModelPath"))
+def test_find(datadir, entry_point):
+    runner = CliRunner()
+    os.chdir(datadir)
+    result = runner.invoke(mmd, ["find", entry_point])
+    assert result.exit_code == 0
+    assert (pathlib.Path(result.stdout.strip()) / "model.py").is_file()
+    # assert result.stdout.strip() == str(datadir)
+
+
+def test_find_absolute_path(datadir):
+    runner = CliRunner()
+    os.chdir(datadir)
+    result = runner.invoke(mmd, ["find", "model:ModelAbsolutePath"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "/"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,6 +90,6 @@ def test_find_absolute_path(datadir):
     result = runner.invoke(mmd, ["find", "model:ModelAbsolutePath"])
     assert result.exit_code == 0
     if sys.platform.startswith("win"):
-        assert result.stdout.strip() == r"C:\\"
+        assert result.stdout.strip() == "C:\\"
     else:
         assert result.stdout.strip() == "/"

--- a/tests/test_cli/model.py
+++ b/tests/test_cli/model.py
@@ -1,0 +1,13 @@
+import pathlib
+
+
+class ModelString:
+    METADATA = "."
+
+
+class ModelPath:
+    METADATA = pathlib.Path(".")
+
+
+class ModelAbsolutePath:
+    METADATA = pathlib.Path("/")


### PR DESCRIPTION
This pull request adds *click* for creating the command line interface. I've also removed the commands of the form `mmd-<subcommand>`, just use `mmd <subcommand>` instead. All of the api functions should now accept a *model* that can be either the name of a component, a path, an entry point to a component, or an instance of a component.