### PR TITLE
Fix object has no attribute '__module__' error

### DIFF
--- a/model_metadata/api.py
+++ b/model_metadata/api.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import pkg_resources
 import sys
+import warnings
 
 from scripting import cp, ln_s
 

--- a/model_metadata/api.py
+++ b/model_metadata/api.py
@@ -55,17 +55,29 @@ def _search_paths(model):
     paths = []
     try:
         path_to_metadata = pathlib.Path(model.METADATA)
-    except (TypeError, AttributeError):
+    except AttributeError:
         pass
+    except TypeError:
+        warnings.warn("object has METADATA attribute but it is not path-like")
     else:
-        paths.append(
-            pkg_resources.resource_filename(model.__module__, "") / path_to_metadata
-        )
+        try:
+            model_module = model.__module__
+        except AttributeError:
+            model_module = model.__class__.__module__
+        finally:
+            paths.append(
+                (
+                    pkg_resources.resource_filename(model_module, "") / path_to_metadata
+                ).resolve()
+            )
 
     try:
         paths.append(pathlib.Path(model))
     except TypeError:
-        paths.append(pathlib.Path(model.__name__))
+        try:
+            paths.append(pathlib.Path(model.__name__))
+        except AttributeError:
+            pass
 
     try:
         paths.append(pathlib.Path(sys.prefix, "share", "csdms") / model)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@ from model_metadata.errors import (
     MetadataNotFoundError,
 )
 
+
 class Model:
 
     pass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,18 +10,34 @@ from model_metadata.errors import (
     MetadataNotFoundError,
 )
 
+class Model:
+
+    pass
+
 
 @pytest.mark.parametrize("as_type", (str, pathlib.Path))
-def test_find_from_object(shared_datadir, as_type):
+def test_find_from_class(shared_datadir, as_type):
     class Model:
         METADATA = as_type(shared_datadir)
     assert shared_datadir.samefile(find(Model))
 
 
 @pytest.mark.parametrize("as_type", (str, pathlib.Path))
+def test_find_from_instance(shared_datadir, as_type):
+    class Model:
+        METADATA = as_type(shared_datadir)
+    assert shared_datadir.samefile(find(Model()))
+
+
+@pytest.mark.parametrize("as_type", (str, pathlib.Path))
 def test_find_from_path(shared_datadir, as_type):
     path_to_metadata = as_type(shared_datadir)
     assert shared_datadir.samefile(find(path_to_metadata))
+
+
+def test_find_from_entry_point(shared_datadir):
+    Model.METADATA = shared_datadir
+    assert shared_datadir.samefile(find(f"{__name__}:Model"))
 
 
 def test_find_bad_model_raises_not_found_error(shared_datadir):


### PR DESCRIPTION
This pull request fixes an error that occurs when trying to find the metadata from an instance of a component that is from an extension module. The reported error is something like,
```python
AttributeError: 'pymt_heatc.lib.heatmodel.HeatModel' object has no attribute '__module__'
```
In this case, `HeatModel()` doesn't have a `__module__` attribute but `HeatModel` does. To accommodate this, we now try `HeatModel.__module__` and then, if that doesn't work, `HeatModel.__class__.__module__`.