### PR TITLE
Truncate floats when passed to IntParameter

### DIFF
--- a/src/model_metadata/model_parameter.py
+++ b/src/model_metadata/model_parameter.py
@@ -382,6 +382,14 @@ class IntParameter(NumberParameter):
         range: tuple[int, int] | None = None,
         units: str | None = None,
     ):
+        if isinstance(value, float):
+            warnings.warn(
+                f"{value}: floating point number passed as an integer parameter, value"
+                f" will be truncated to {int(value)}",
+                stacklevel=2,
+            )
+            value = int(value)
+
         if not isinstance(value, (int, str)):
             raise ValueError(
                 "value must be either an int or a string that can be converted to"

--- a/src/model_metadata/model_parameter.py
+++ b/src/model_metadata/model_parameter.py
@@ -238,13 +238,13 @@ class NumberParameter(ModelParameter):
         if range_ is not None and len(range_) != 2:
             raise ValueError("range must be either None or (min, max)")
 
-        try:
-            value = int(value)
-        except ValueError:
-            value = float(value)
-        finally:
-            if not isinstance(value, (int, float)):
-                raise ValueError("value is not a number")
+        if isinstance(value, str):
+            try:
+                value = int(value)
+            except ValueError:
+                value = float(value)
+        if not isinstance(value, (int, float)):
+            raise ValueError("value is not a number")
 
         super().__init__(value, desc=desc)
 

--- a/tests/parameter_test.py
+++ b/tests/parameter_test.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+from model_metadata.model_parameter import FloatParameter
+from model_metadata.model_parameter import IntParameter
+
+
+@pytest.mark.parametrize("value", (1973, 1973.0, 1973.5, "1973"))
+def test_int_parameter(value):
+    p = IntParameter(value)
+    assert isinstance(p.value, int)
+    assert p.value == 1973
+
+
+@pytest.mark.parametrize("value", (3.14, "3.14"))
+def test_float_parameter(value):
+    p = FloatParameter(value)
+    assert isinstance(p.value, float)
+    assert p.value == 3.14


### PR DESCRIPTION
This pull request should fix #29.

With *v0.8.0*, I made a change to `IntParameter` whereby if it was passed a *float*, an error was raised. In the past, the float would have silently converted to an *int*. This PR makes a change so that, in such a circumstance, the floating point value is truncated and an warning is issued.

In #29, this was a problem when loading metadata from *pymt_cem* because it contained the following section in its parameters file,
```yaml
run_duration:
  description: Simulation run time
  value:
    default: 3650.0
    range:
      max: 1.79769313486e+308
      min: 1.0
    type: int
    units: d
```
Notice the default is a *float* but the type is *int*.