### PR TITLE
Add parameters keyword to stage function

### DIFF
--- a/src/model_metadata/api.py
+++ b/src/model_metadata/api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
+
+from model_metadata.errors import UnknownKeyError
 from model_metadata.model_setup import FileSystemLoader
 from model_metadata.model_setup import OldFileSystemLoader
 from model_metadata.modelmetadata import ModelMetadata
@@ -77,3 +80,8 @@ def stage(
         manifest = FileSystemLoader(mmd).stage_all(dest, **defaults)
 
     return manifest
+
+
+def _check_for_unknown_keys(allowed: Iterable[str], user: Iterable[str]) -> None:
+    if unknown_keys := (set(user) - set(allowed)):
+        raise UnknownKeyError(unknown_keys)

--- a/src/model_metadata/api.py
+++ b/src/model_metadata/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
 
 from model_metadata.errors import UnknownKeyError
 from model_metadata.model_setup import FileSystemLoader
@@ -55,7 +56,10 @@ def query(model: str, var: str) -> ModelMetadata:
 
 
 def stage(
-    model: str, dest: str = ".", old_style_templates: bool = False
+    model: str,
+    dest: str = ".",
+    old_style_templates: bool = False,
+    parameters: dict[str, Any] | None = None,
 ) -> tuple[str, ...]:
     """Stage a model by setting up its input files.
 
@@ -65,14 +69,30 @@ def stage(
         The model is interpreted either as a path to a folder that
         contains metadata, the name of a model component, or a
         model object.
-    dest : str
+    dest : str, optional
         Path to a folder within which to stage the model.
+    parameters : dict[str, Any], optional
+        A dictionary of parameters that overrides the default
+        values.
     """
+    parameters = {} if parameters is None else parameters
+
     defaults = {}
     mmd = ModelMetadata.find(model)
     meta = ModelMetadata(mmd)
     for param, item in meta.parameters.items():
         defaults[param] = item["value"]["default"]
+
+    try:
+        _check_for_unknown_keys(defaults.keys(), parameters.keys())
+    except UnknownKeyError as e:
+        e.add_note(
+            f"valid parameter{'s' if len(defaults) > 1 else ''}:"
+            f" {', '.join(sorted(repr(k) for k in defaults))}"
+        )
+        raise
+
+    defaults = {**defaults, **parameters}
 
     if old_style_templates:
         manifest = OldFileSystemLoader(mmd).stage_all(dest, **defaults)

--- a/src/model_metadata/errors.py
+++ b/src/model_metadata/errors.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 
 class ModelMetadataError(Exception):
     """Base error for model_metadata package."""
@@ -55,3 +57,16 @@ class BadEntryPointError(ModelMetadataError):
 
     def __str__(self) -> str:
         return self._entry_point + f": {self._msg}" if self._msg else ""
+
+
+class UnknownKeyError(ModelMetadataError):
+    """Raise if a dictionary contains one or more unrecognized keys."""
+
+    def __init__(self, unknown: Iterable[str]) -> None:
+        super().__init__(*sorted(set(unknown)))
+
+    def __str__(self) -> str:
+        return (
+            f"unknown key{'s' if len(self.args) > 1 else ''}:"
+            f" {', '.join(repr(key) for key in self.args)}"
+        )


### PR DESCRIPTION
I've added a new keyword, `parameters`, to the `stage` function. This allows a user to pass a set of parameters that will override the defaults. If not provided, default will be used as before.