### PR TITLE
Switch from coveralls to CodeCov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,25 +76,6 @@ jobs:
           pip install nox
           nox --non-interactive --error-on-missing-interpreter -s test test-cli -- dist/*.tar.gz
 
-      - name: Coveralls
-        if: matrix.os == 'ubuntu-latest'
-        uses: AndreMiras/coveralls-python-action@develop
-        with:
-          parallel: true
-          flag-name: py${{ matrix.python-version }}-${{ matrix.os }}
-
-          debug: true
-
-  coveralls_finish:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: AndreMiras/coveralls-python-action@develop
-        with:
-          parallel-finished: true
-          debug: true
-
   publish:
     needs:
       - check-tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,11 @@ jobs:
           pip install nox
           nox --non-interactive --error-on-missing-interpreter -s test test-cli -- dist/*.tar.gz
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   publish:
     needs:
       - check-tag

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,14 +16,16 @@ def test(session: nox.Session) -> None:
     session.install("-r", "requirements-testing.txt")
     install(session)
 
-    args = ["--cov", PROJECT, "-vvv"]
-
-    if "CI" in os.environ:
-        args.append(f"--cov-report=xml:{ROOT.absolute()!s}/coverage.xml")
-    session.run("pytest", *args)
-
-    if "CI" not in os.environ:
-        session.run("coverage", "report", "--ignore-errors", "--show-missing")
+    session.run(
+        "coverage",
+        "run",
+        "--branch",
+        "--source=model_metadata,tests",
+        "--module",
+        "pytest",
+    )
+    session.run("coverage", "report", "--ignore-errors", "--show-missing")
+    session.run("coverage", "xml", "-o", "coverage.xml")
 
 
 @nox.session(name="test-cli")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,8 @@ dev = [
     "nox",
 ]
 testing = [
-    "coveralls",
+    "coverage",
     "pytest",
-    "pytest-cov",
     "pytest-datadir",
 ]
 

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,3 @@
-coveralls
-pytest-cov
+coverage
 pytest-datadir
 pytest>=3.6


### PR DESCRIPTION
I've switched from *coveralls* to *CodeCov* for coverage in our ci.